### PR TITLE
Prevent searching when query is empty

### DIFF
--- a/src/Http/Livewire/Editor.php
+++ b/src/Http/Livewire/Editor.php
@@ -99,6 +99,11 @@ class Editor extends Component
 	 */
 	public function search() : void
 	{
+		if (empty($this->query)) {
+			$this->resetSearch();
+			return;
+		}
+		
 		$this->eligebleForPermission = $this->getAction()->search($this->query)->get();
 		$this->isSearching = true;
 	}


### PR DESCRIPTION
As an added bonus, clear previous search results.